### PR TITLE
Trigger pages deploy from microCMS webhook

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -12,6 +12,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Allow this workflow to be called from other workflows
+  workflow_call:
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/microcms.yml
+++ b/.github/workflows/microcms.yml
@@ -1,13 +1,9 @@
 name: microCMS webhook
 on:
   workflow_dispatch:
-  repository_dispatch: # microCMS webhook
+  repository_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: test
-        run: |
-          echo "test"
+  deploy:
+    uses: ./.github/workflows/build-deploy.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary
- allow `build-deploy.yml` workflow to be called from other workflows
- add `microcms.yml` that reuses the deploy workflow when `repository_dispatch` triggers

## Testing
- `bun run lint` *(fails: `next` not found)*
- `bun run build` *(fails: cannot find package `feed`)*


------
https://chatgpt.com/codex/tasks/task_e_68543eed950c8329ba9ea8218d2995dd