### PR TITLE
Add sitemap generation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 https://hondaya.co
+
+## Sitemap and robots
+
+The build script generates `public/sitemap.xml` using `bun run gen-sitemap`. The `public/robots.txt` file references the sitemap so crawlers can index pages correctly.

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "bun run gen-rss && next build",
+    "build": "bun run gen-rss && bun run gen-sitemap && next build",
     "start": "next start",
     "lint": "next lint",
-    "gen-rss": "bun run script/generate-rss.ts"
+    "gen-rss": "bun run script/generate-rss.ts",
+    "gen-sitemap": "bun run script/generate-sitemap.ts"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://hondaya.co/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hondaya.co/</loc>
+    <lastmod>1970-01-01</lastmod>
+  </url>
+</urlset>

--- a/script/generate-sitemap.ts
+++ b/script/generate-sitemap.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Article, getArticles } from '../src/lib/microcms';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function generateSitemap() {
+  try {
+    console.log('\uD83C\uDFC3\u200D\u2640\uFE0F Start generate sitemap...');
+
+    if (!process.env.MICROCMS_API_KEY) {
+      throw new Error('Not setted MICROCMS_API_KEY.');
+    }
+
+    const { contents } = await getArticles();
+    console.log(`\u2705 Got ${contents.length} articles`);
+
+    const siteURL = 'https://hondaya.co';
+    const staticPaths = ['', '/blog', '/privacy'];
+
+    const urls = [
+      ...staticPaths.map((p) => ({ loc: `${siteURL}${p}`, lastmod: new Date().toISOString() })),
+      ...contents.map((post: Article) => ({ loc: `${siteURL}/blog/${post.id}`, lastmod: post.publishedAt })),
+    ];
+
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+      urls.map((u) => `  <url><loc>${u.loc}</loc><lastmod>${u.lastmod}</lastmod></url>`).join('\n') +
+      '\n</urlset>';
+
+    const outputPath = path.join(__dirname, '../public/sitemap.xml');
+    fs.writeFileSync(outputPath, xml);
+
+    console.log(`\uD83C\uDD97 Generated sitemap: ${outputPath}`);
+    return true;
+  } catch (error) {
+    console.error('\u274C Error occurred while generating sitemap:', error);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  generateSitemap();
+}
+
+export default generateSitemap;


### PR DESCRIPTION
## Summary
- document sitemap generation
- include a placeholder `sitemap.xml`

## Testing
- `bun run lint` *(fails: next not installed)*
- `MICROCMS_API_KEY=dummy bun run gen-sitemap` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685576bbafb083299d50ff2e496c2609