### PR TITLE
Fix blog HTML formatting and add Twitter embed

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { Calendar, ArrowLeft } from 'lucide-react'
 import { Metadata } from 'next'
+import Script from 'next/script'
 
 export const revalidate = 60
 
@@ -53,6 +54,7 @@ export default async function BlogDetailPage(props: { params: Promise<{ id: stri
     const article = await getArticle(resolvedParams.id)
     const publishDate = new Date(article.publishedAt)
     const formattedDate = `${publishDate.getFullYear()}/${String(publishDate.getMonth() + 1).padStart(2, '0')}/${String(publishDate.getDate()).padStart(2, '0')}`
+    const formattedContent = article.content.replace(/\n/g, '<br />')
     
     return (
       <div className="min-h-screen bg-white dark:bg-gray-900">
@@ -101,8 +103,9 @@ export default async function BlogDetailPage(props: { params: Promise<{ id: stri
               </div>
             )}
             
-            <div className="mt-8 prose-lg" dangerouslySetInnerHTML={{ __html: article.content }} />
+            <div className="mt-8 prose-lg" dangerouslySetInnerHTML={{ __html: formattedContent }} />
           </article>
+          <Script src="https://platform.twitter.com/widgets.js" strategy="afterInteractive" />
         </main>
         
         <footer className="mt-12 py-8 border-t border-gray-200 dark:border-gray-800">


### PR DESCRIPTION
## Summary
- preserve newlines from CMS content
- include Twitter embed script for blog posts

## Testing
- `bun run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d710364a883298b72ba8d8def558d