### PR TITLE
Fix blog HTML sanitization

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { Calendar, ArrowLeft } from 'lucide-react'
 import { Metadata } from 'next'
+import Script from 'next/script'
+import SanitizedHtml from '@/components/SanitizedHtml'
 
 export const revalidate = 60
 
@@ -101,8 +103,9 @@ export default async function BlogDetailPage(props: { params: Promise<{ id: stri
               </div>
             )}
             
-            <div className="mt-8 prose-lg" dangerouslySetInnerHTML={{ __html: article.content }} />
+            <SanitizedHtml className="mt-8 prose-lg" html={article.content} />
           </article>
+          <Script src="https://platform.twitter.com/widgets.js" strategy="afterInteractive" />
         </main>
         
         <footer className="mt-12 py-8 border-t border-gray-200 dark:border-gray-800">

--- a/src/components/SanitizedHtml.tsx
+++ b/src/components/SanitizedHtml.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { useMemo } from 'react'
+import DOMPurify from 'dompurify'
+
+export default function SanitizedHtml({ html, className }: { html: string; className?: string }) {
+  const sanitized = useMemo(() => DOMPurify.sanitize(html), [html])
+
+  return <div className={className} dangerouslySetInnerHTML={{ __html: sanitized }} />
+}


### PR DESCRIPTION
## Summary
- sanitize HTML from CMS with DOMPurify
- keep Twitter embed script in blog detail page

## Testing
- `bun run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d710364a883298b72ba8d8def558d