### PR TITLE
Adjust DOMPurify link handling

### DIFF
--- a/src/components/SanitizedHtml.tsx
+++ b/src/components/SanitizedHtml.tsx
@@ -1,10 +1,24 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useEffect } from 'react'
 import DOMPurify from 'dompurify'
 
 export default function SanitizedHtml({ html, className }: { html: string; className?: string }) {
-  const sanitized = useMemo(() => DOMPurify.sanitize(html), [html])
+  useEffect(() => {
+    const hook = (node: Element) => {
+      if (node.nodeName === 'A') {
+        node.setAttribute('target', '_blank')
+        // ensure new tabs do not leak the opener but keep the referrer
+        node.setAttribute('rel', 'noopener')
+      }
+    }
+    DOMPurify.addHook('afterSanitizeAttributes', hook)
+    return () => {
+      DOMPurify.removeHook('afterSanitizeAttributes', hook)
+    }
+  }, [])
+
+  const sanitized = useMemo(() => DOMPurify.sanitize(html, { USE_PROFILES: { html: true } }), [html])
 
   return <div className={className} dangerouslySetInnerHTML={{ __html: sanitized }} />
 }


### PR DESCRIPTION
## Summary
- update `SanitizedHtml` so anchor tags only use `rel="noopener"`

## Testing
- `bun run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de868a18083298303ef12eed19d93