### PR TITLE
Remove ad placeholder text

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -75,7 +75,7 @@ export default async function BlogDetailPage(props: { params: Promise<{ id: stri
                 <div className="bg-[#EFEEDF] rounded-lg p-6 shadow-sm border border-[#4C4948]">
                   <h3 className="font-semibold mb-3 text-[#4C4948]">Advertisement</h3>
                   <div className="h-64 bg-[#EFEEDF] border border-[#4C4948] rounded flex items-center justify-center text-[#4C4948]">
-                    Ad Space
+
                   </div>
                 </div>
                 <div className="bg-[#EFEEDF] rounded-lg p-6 shadow-sm border border-[#4C4948]">

--- a/src/app/blog/blog.tsx
+++ b/src/app/blog/blog.tsx
@@ -44,7 +44,7 @@ export default function BlogClient({ articles }: { articles: Article[] }) {
               <div className="bg-[#EFEEDF] rounded-lg p-6 shadow-sm border border-[#4C4948]">
                 <h3 className="font-semibold mb-3 text-[#4C4948]">Advertisement</h3>
                 <div className="h-64 bg-[#EFEEDF] border border-[#4C4948] rounded flex items-center justify-center text-[#4C4948]">
-                  Ad Space
+
                 </div>
               </div>
               <div className="bg-[#EFEEDF] rounded-lg p-6 shadow-sm border border-[#4C4948]">


### PR DESCRIPTION
## Summary
- remove placeholder text inside advertisement frames on blog pages

## Testing
- `bun run lint` *(fails: `next: command not found`)*
- `bun install` *(fails: network 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871e4b62bb88329b1e0a9f025e52381