### PR TITLE
Switch to Noto Sans JP font

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,7 +9,7 @@
 :root {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-noto-sans-jp);
   --font-mono: var(--font-geist-mono);
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,15 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
+import { Noto_Sans_JP } from "next/font/google";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
 import GoogleAdSense from "@/components/GoogleAdSense";
 import PWAHead from "@/components/PWAHead";
 import "./globals.css";
 
 
-const lineSeedFont = localFont({
-  src: './LINESeedSans_W_XBd.woff2',
+const notoSansJp = Noto_Sans_JP({
+  subsets: ['latin'],
+  weight: ['400', '700'],
+  variable: '--font-noto-sans-jp',
 })
 
 export const metadata: Metadata = {
@@ -31,9 +33,7 @@ export default function RootLayout({
         {/* PWA Manifest & Apple settings */}
         <PWAHead/>
       </head>
-      <body
-        className={`${lineSeedFont.className} antialiased`}
-      >
+      <body className={`${notoSansJp.className} antialiased`}>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- load Noto Sans JP using `next/font/google`
- apply the font to the `<body>` element
- reference the font via `--font-noto-sans-jp` in CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a11cadb6883299e0b5f34532ce220