### PR TITLE
Improve blockquote styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -133,3 +133,32 @@ article a.no-underline h3,
 article a.no-underline p {
   text-decoration: none !important;
 }
+
+/* Blockquote styling */
+
+blockquote {
+  border-left: 4px solid #4C4948;
+  padding-left: 1rem;
+  margin: 1rem 0;
+  font-style: italic;
+  color: #4C4948;
+}
+
+blockquote::before {
+  content: "\201C"; /* left double quotation mark */
+  font-size: 2rem;
+  line-height: 0;
+  margin-right: 0.25rem;
+  vertical-align: -0.4rem;
+  color: #4C4948;
+}
+
+@media (prefers-color-scheme: dark) {
+  blockquote {
+    border-color: #ffffff;
+    color: #ffffff;
+  }
+  blockquote::before {
+    color: #ffffff;
+  }
+}

--- a/src/components/MDXComponents.tsx
+++ b/src/components/MDXComponents.tsx
@@ -75,7 +75,7 @@ export const MDXComponents = {
   
   // ブロッククォート
   blockquote: ({ children, ...props }: BlockquoteProps) => (
-    <blockquote className="border-l-4 border-blue-500 pl-4 italic text-gray-700 dark:text-gray-300" {...props}>
+    <blockquote {...props}>
       {children}
     </blockquote>
   ),


### PR DESCRIPTION
## Summary
- add quote design for `<blockquote>` elements
- rely on global CSS styling in MDX

## Testing
- `bun run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb296031c8329803c6d7cd6f463b8