### PR TITLE
Use Amazon Product Advertising API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,7 @@
 MICROCMS_API_KEY=your-api-key
+AMAZON_ACCESS_KEY=
+AMAZON_SECRET_KEY=
+AMAZON_PARTNER_TAG=
+AMAZON_REGION=us-east-1
+AMAZON_HOST=webservices.amazon.co.jp
+AMAZON_MARKETPLACE=www.amazon.co.jp

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ bun run build
 
 ## Environment Variables
 
-Access to microCMS requires the `MICROCMS_API_KEY` environment variable. See `.env.example` for the required key name.
+Access to microCMS requires the `MICROCMS_API_KEY` environment variable.
+Fetching Amazon product data uses the Product Advertising API and requires the
+`AMAZON_ACCESS_KEY`, `AMAZON_SECRET_KEY` and `AMAZON_PARTNER_TAG` variables.
+See `.env.example` for all required keys.
 
 ## Scripts
 

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -7,6 +7,8 @@ interface OGPData {
   image?: string
   url?: string
   siteName?: string
+  price?: string
+  availability?: string
 }
 
 interface LinkCardProps {
@@ -60,6 +62,12 @@ export function LinkCard({ url, children, ogpData, size = 'small' }: LinkCardPro
           {ogpData.description && (
             <p className={`${isLarge ? 'text-sm' : 'text-xs'} text-gray-300 line-clamp-2 ${isLarge ? '' : 'mb-2'}`}>
               {ogpData.description}
+            </p>
+          )}
+          {(ogpData.price || ogpData.availability) && (
+            <p className={`${isLarge ? 'text-sm' : 'text-xs'} text-gray-300 ${isLarge ? '' : 'mb-2'}`}>
+              {ogpData.price}
+              {ogpData.availability ? ` (${ogpData.availability})` : ''}
             </p>
           )}
           <div className={`flex items-center ${isLarge ? 'gap-2' : 'gap-1'} text-xs text-gray-400`}>

--- a/src/lib/amazon.ts
+++ b/src/lib/amazon.ts
@@ -1,4 +1,4 @@
-import * as cheerio from 'cheerio'
+import crypto from 'crypto'
 
 export interface AmazonProductInfo {
   title?: string
@@ -6,55 +6,159 @@ export interface AmazonProductInfo {
   image?: string
   url?: string
   siteName?: string
+  price?: string
+  availability?: string
+}
+
+interface PAAPIItem {
+  ItemInfo?: {
+    Title?: { DisplayValue?: string }
+    Features?: { DisplayValues?: string[] }
+  }
+  Images?: { Primary?: { Large?: { URL?: string } } }
+  Offers?: {
+    Listings?: Array<{
+      Price?: { DisplayAmount?: string }
+      Availability?: { Message?: string }
+    }>
+  }
+}
+
+interface PAAPIResponse {
+  ItemsResult?: { Items?: PAAPIItem[] }
+}
+
+function sign(key: string | Buffer, msg: string) {
+  return crypto.createHmac('sha256', key).update(msg, 'utf8').digest()
+}
+
+function getSignatureKey(key: string, dateStamp: string, regionName: string, serviceName: string) {
+  const kDate = sign('AWS4' + key, dateStamp)
+  const kRegion = sign(kDate, regionName)
+  const kService = sign(kRegion, serviceName)
+  return sign(kService, 'aws4_request')
+}
+
+function extractASIN(url: string): string | null {
+  try {
+    const asinMatch = url.match(/(?:dp|gp\/product)\/([A-Z0-9]{10})/i)
+    if (asinMatch) return asinMatch[1]
+    const urlObj = new URL(url)
+    const parts = urlObj.pathname.split('/')
+    for (const part of parts) {
+      if (/^[A-Z0-9]{10}$/.test(part)) return part
+    }
+  } catch {
+    // ignore
+  }
+  return null
 }
 
 export async function fetchAmazonProductInfo(url: string): Promise<AmazonProductInfo | null> {
+  const asin = extractASIN(url)
+  if (!asin) {
+    console.error('Failed to extract ASIN from URL:', url)
+    return null
+  }
+
+  const accessKey = process.env.AMAZON_ACCESS_KEY
+  const secretKey = process.env.AMAZON_SECRET_KEY
+  const partnerTag = process.env.AMAZON_PARTNER_TAG
+  const region = process.env.AMAZON_REGION || 'us-east-1'
+  const host = process.env.AMAZON_HOST || 'webservices.amazon.co.jp'
+  const marketplace = process.env.AMAZON_MARKETPLACE || 'www.amazon.co.jp'
+
+  if (!accessKey || !secretKey || !partnerTag) {
+    console.error('Amazon PA-API environment variables are not set')
+    return null
+  }
+
+  const service = 'ProductAdvertisingAPI'
+  const endpoint = `https://${host}/paapi5/getitems`
+  const now = new Date()
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '')
+  const dateStamp = amzDate.slice(0, 8)
+
+  const payload = JSON.stringify({
+    ItemIds: [asin],
+    Resources: [
+      'Images.Primary.Large',
+      'ItemInfo.Title',
+      'Offers.Listings.Price',
+      'Offers.Listings.Availability'
+    ],
+    PartnerTag: partnerTag,
+    PartnerType: 'Associates',
+    Marketplace: marketplace
+  })
+
+  const canonicalHeaders = [
+    'content-encoding:amz-1.0',
+    'content-type:application/json; charset=utf-8',
+    `host:${host}`,
+    `x-amz-date:${amzDate}`
+  ].join('\n') + '\n'
+  const signedHeaders = 'content-encoding;content-type;host;x-amz-date'
+  const payloadHash = crypto.createHash('sha256').update(payload, 'utf8').digest('hex')
+  const canonicalRequest = [
+    'POST',
+    '/paapi5/getitems',
+    '',
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash
+  ].join('\n')
+
+  const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    credentialScope,
+    crypto.createHash('sha256').update(canonicalRequest, 'utf8').digest('hex')
+  ].join('\n')
+
+  const signingKey = getSignatureKey(secretKey, dateStamp, region, service)
+  const signature = crypto.createHmac('sha256', signingKey).update(stringToSign, 'utf8').digest('hex')
+
+  const authorizationHeader =
+    `AWS4-HMAC-SHA256 Credential=${accessKey}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`
+
+  const headers = {
+    'Content-Encoding': 'amz-1.0',
+    'Content-Type': 'application/json; charset=utf-8',
+    'X-Amz-Date': amzDate,
+    Authorization: authorizationHeader,
+    Host: host
+  }
+
   try {
-    // Amazon側でbotブロックが原因でOGP取得が不安定になる問題を修正
-    // User-Agentヘッダーを追加してブラウザからのリクエストとして認識させる
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        'Accept-Language': 'ja,en-US;q=0.9,en;q=0.8',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'Cache-Control': 'no-cache',
-        'Pragma': 'no-cache'
-      }
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: payload
     })
 
     if (!response.ok) {
-      throw new Error('Failed to fetch Amazon page')
+      throw new Error(`Failed to fetch Amazon product info: ${response.status}`)
     }
 
-    console.log('Success for fetching Amazon product info: ', url)
-
-    const html = await response.text()
-    const $ = cheerio.load(html)
-
-    // Amazon商品情報の抽出
-    const title = $('#productTitle').text().trim() || 
-                  $('h1.a-size-large').text().trim() ||
-                  $('h1').first().text().trim()
-
-    // 商品画像の取得
-    const image = $('#landingImage').attr('src') ||
-                  $('.a-dynamic-image').first().attr('src') ||
-                  $('img[data-old-hires]').first().attr('data-old-hires')
-
-    // 商品説明の取得
-    const description = $('#feature-bullets ul li').first().text().trim() ||
-                        $('.a-unordered-list.a-nostyle.a-vertical').first().text().trim().slice(0, 200)
+    const data = (await response.json()) as PAAPIResponse
+    const item = data.ItemsResult?.Items?.[0]
+    if (!item) {
+      throw new Error('No item information returned')
+    }
 
     return {
-      title: title || 'Amazon',
-      description: description || 'Please check the product page for more details.',
-      image: image || undefined,
+      title: item.ItemInfo?.Title?.DisplayValue,
+      description: item.ItemInfo?.Features?.DisplayValues?.[0],
+      image: item.Images?.Primary?.Large?.URL,
       siteName: 'Amazon',
-      url: url
+      url,
+      price: item.Offers?.Listings?.[0]?.Price?.DisplayAmount,
+      availability: item.Offers?.Listings?.[0]?.Availability?.Message
     }
   } catch (error) {
-    console.error('Error scraping Amazon product:', error)
+    console.error('Error fetching Amazon product info via PA-API:', error)
     return null
   }
 }

--- a/src/lib/ogp.ts
+++ b/src/lib/ogp.ts
@@ -7,6 +7,8 @@ export interface OGPData {
   image?: string
   url?: string
   siteName?: string
+  price?: string
+  availability?: string
 }
 
 export async function fetchOGPData(url: string): Promise<OGPData | null> {
@@ -17,7 +19,7 @@ export async function fetchOGPData(url: string): Promise<OGPData | null> {
     }
 
     // 通常のOGP取得
-    const { result } = await ogs({ 
+    const { result } = await ogs({
       url,
       timeout: 10000
     })
@@ -28,7 +30,9 @@ export async function fetchOGPData(url: string): Promise<OGPData | null> {
       description: result.ogDescription,
       image: result.ogImage?.[0]?.url,
       siteName: result.ogSiteName,
-      url: result.ogUrl || url
+      url: result.ogUrl || url,
+      price: undefined,
+      availability: undefined
     }
   } catch {
     console.error('Error fetching OGP data:', url)


### PR DESCRIPTION
## Summary
- switch Amazon scraping to use Product Advertising API
- expose Amazon API credentials via environment variables
- show Amazon price and availability in link cards
- document new variables in README

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68881a654da08329a5d07d620d09cf45