### PR TITLE
feat: add blog overview with Zenn link

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,9 +1,37 @@
-import { getArticles } from '@/lib/microcms'
-import BlogClient from './blog'
+import Link from 'next/link'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faRss } from '@fortawesome/free-solid-svg-icons'
+import ZennIcon from '@/components/ZennIcon'
 
-export const revalidate = 60
+export const metadata = {
+  title: 'Blog',
+}
 
-export default async function BlogPage() {
-  const data = await getArticles()
-  return <BlogClient articles={data.contents} />
+export default function BlogPage() {
+  const entries = [
+    { href: '/blog/posts', label: 'Self-hosted Blog', icon: <FontAwesomeIcon icon={faRss} className="w-6 h-6" /> },
+    { href: 'https://zenn.dev/hondaya14', label: 'Zenn', icon: <ZennIcon className="w-6 h-6" /> },
+  ]
+
+  return (
+    <div className="min-h-screen bg-[#101114] text-white p-8">
+      <div className="max-w-2xl mx-auto space-y-8">
+        <h1 className="text-3xl font-semibold">Blog</h1>
+        <ul className="space-y-4">
+          {entries.map(({ href, label, icon }) => (
+            <li key={href}>
+              <Link
+                href={href}
+                target={href.startsWith('http') ? '_blank' : undefined}
+                className="flex items-center gap-4 p-4 border border-gray-600 rounded no-underline hover:bg-gray-600/10"
+              >
+                {icon}
+                <span className="text-lg">{label}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
 }

--- a/src/app/blog/posts/page.tsx
+++ b/src/app/blog/posts/page.tsx
@@ -1,0 +1,9 @@
+import { getArticles } from '@/lib/microcms'
+import BlogClient from '../blog'
+
+export const revalidate = 60
+
+export default async function PostsPage() {
+  const data = await getArticles()
+  return <BlogClient articles={data.contents} />
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,19 +4,7 @@ import { faGithub, faLinkedin, faXTwitter } from "@fortawesome/free-brands-svg-i
 import Link from "next/link";
 import { faRss, faLink } from "@fortawesome/free-solid-svg-icons";
 import { lineSeedFont } from "@/lib/fonts";
-
-// const ZennIcon = () => {
-//   return (
-//     <Image 
-//       src="/zenn-logo-only.svg"
-//       alt="Zenn Icon"
-//       width={40}
-//       height={40}
-//       className="w-10 h-10"
-//       title="Zenn"
-//     />
-//   );
-// };
+import ZennIcon from "@/components/ZennIcon";
 
 export default function Home() {
   return (
@@ -48,9 +36,9 @@ export default function Home() {
           {/* <Link title="Instagram" href="https://www.instagram.com/nqv_no" target="_blank">
             <FontAwesomeIcon icon={faInstagram} className="w-10 "/>
           </Link> */}
-          {/* <Link title="Zenn" href="https://zenn.dev/hondaya14" target="_blank">
+          <Link title="Zenn" href="https://zenn.dev/hondaya14" target="_blank">
             <ZennIcon/>
-          </Link> */}
+          </Link>
         </div>
       </div>
     </div>

--- a/src/components/ZennIcon.tsx
+++ b/src/components/ZennIcon.tsx
@@ -1,0 +1,18 @@
+import Image from 'next/image'
+
+interface ZennIconProps {
+  className?: string
+}
+
+export default function ZennIcon({ className = 'w-10 h-10' }: ZennIconProps) {
+  return (
+    <Image
+      src="/zenn-logo-only.svg"
+      alt="Zenn"
+      width={40}
+      height={40}
+      className={className}
+      title="Zenn"
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- extract reusable ZennIcon component
- add blog index page listing self-hosted and Zenn entries
- move existing article list to `/blog/posts`

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a85b66d4108329837654342a78e1e9