### PR TITLE
Add CI workflow to verify build

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,26 @@
+name: Verify build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      MICROCMS_API_KEY: ${{ secrets.MICROCMS_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run build
+        run: bun run build


### PR DESCRIPTION
## Summary
- add a reusable GitHub Actions workflow that runs `bun run build` so CI fails if the Next.js build breaks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de3c70088832999b8b03701c442c9)